### PR TITLE
added multitenancy addons in install scripts serverless and config

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "serverless-bundle": "^4.4.0",
     "serverless-offline": "^8.2.0",
     "serverless-step-functions": "^3.1.1",
+    "serverless-plugin-ifelse": "^1.0.7",
     "sinon": "^9.0.2",
     "tmp-promise": "^3.0.2",
     "ts-jest": "^26.4.4",

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -16,11 +16,26 @@ custom:
   config: ${file(serverless_config.json)}
   useHapiValidator: ${opt:useHapiValidator, 'false'}
   enableMultiTenancy: ${opt:enableMultiTenancy, 'false'}
+  useTenantSpecificUrl: ${opt:useTenantSpecificUrl, 'true'}
+  tenantIdClaimPath: ${opt:tenantIdClaimPath, ""}
+  tenantIdClaimValuePrefix: ${opt:tenantIdClaimValuePrefix, ""}
+  grantAccessAllTenantsScope: ${opt:grantAccessAllTenantsScope, ""}
   enableSubscriptions: ${opt:enableSubscriptions, 'false'}
   logLevel: ${opt:logLevel, 'error'}
   enableESHardDelete: ${opt:enableESHardDelete, 'false'}
   patientCompartmentFileV3: 'patientCompartmentSearchParams.3.0.2.json'
   patientCompartmentFileV4: 'patientCompartmentSearchParams.4.0.1.json'
+  # serverlessIfElse: Helps to configure the API Gateway in order to support multi tenancy with specific url cleanly
+  serverlessIfElse:
+      - If: '"${self:custom.enableMultiTenancy}" == "true" && "${self:custom.useTenantSpecificUrl}" == "true"'
+        Exclude:
+          - resources.extensions.ApiGatewayMethodMetadataGet
+        Set:
+          functions.fhirServer.events.0.http.path: '/tenant/{tenantId}/' 
+          functions.fhirServer.events.1.http.path: '/tenant/{tenantId}/{proxy+}' 
+          functions.fhirServer.events.2.http.path: /tenant/{tenantId}/metadata
+        ElseExclude:
+            - resources.extensions.ApiGatewayMethodTenantTenantidVarMetadataGet
   bundle:
     packager: yarn
     linting: false # We use our own linter
@@ -65,6 +80,10 @@ provider:
       - !ImportValue 'fhir-service-validator-lambda-${self:custom.stage}'
       - !Ref AWS::NoValue
     ENABLE_MULTI_TENANCY: !Ref EnableMultiTenancy
+    USE_TENANT_SPECIFIC_URL: !Ref UseTenantSpecificUrl
+    TENANT_ID_CLAIM_PATH: '${self:custom.tenantIdClaimPath}'
+    TENANT_ID_CLAIM_VALUE_PREFIX: '${self:custom.tenantIdClaimValuePrefix}'
+    GRANT_ACCESS_ALL_TENANTS_SCOPE: '${self:custom.grantAccessAllTenantsScope}'
     ENABLE_SUBSCRIPTIONS: !Ref EnableSubscriptions
     LOG_LEVEL: '${self:custom.logLevel}'
   apiKeys:
@@ -105,9 +124,6 @@ functions:
       - http:
           method: GET
           path: /metadata
-      - http:
-          method: GET
-          path: /tenant/{tenantId}/metadata
     handler: src/index.handler
     provisionedConcurrency: 5
     environment:
@@ -276,6 +292,13 @@ resources:
           - 'true'
           - 'false'
         Description: whether or not to enable multi-tenancy
+      UseTenantSpecificUrl:
+        Type: String
+        Default: ${self:custom.useTenantSpecificUrl}
+        AllowedValues:
+          - 'true'
+          - 'false'
+        Description: whether or not to enable the use a tenant specific url
       EnableSubscriptions:
         Type: String
         Default: ${self:custom.enableSubscriptions}
@@ -1078,6 +1101,13 @@ resources:
               - id: W45
                 reason: 'This API endpoint should not require authentication (due to the FHIR spec)'
 
+      ApiGatewayMethodTenantTenantidVarMetadataGet:
+        Metadata:
+          cfn_nag:
+            rules_to_suppress:
+              - id: W45
+                reason: 'This API endpoint should not require authentication (due to the FHIR spec)'
+
   - ${file(cloudformation/alarms.yaml)}
   - ${file(cloudformation/kms.yaml)}
   - ${file(cloudformation/elasticsearch.yaml)}
@@ -1157,3 +1187,4 @@ plugins:
   - serverless-step-functions
   - serverless-bundle
   - serverless-offline
+  - serverless-plugin-ifelse

--- a/src/RBACRules.ts
+++ b/src/RBACRules.ts
@@ -41,6 +41,11 @@ const RBACRules = (baseResources: string[]): RBACConfig => {
                 resources: ['Patient'],
             },
         },
+        scopeToGroup: {
+            'fhir/practitioner': 'practitioner',
+            'fhir/non-practitioner': 'non-practitioner',
+            'fhir/auditor': 'auditor',
+        },
     };
 };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,9 +27,17 @@ import getAllowListedSubscriptionEndpoints from './subscriptions/allowList';
 import RBACRules from './RBACRules';
 import { loadImplementationGuides } from './implementationGuides/loadCompiledIGs';
 
-const { IS_OFFLINE, ENABLE_MULTI_TENANCY, ENABLE_SUBSCRIPTIONS } = process.env;
+const { IS_OFFLINE, ENABLE_MULTI_TENANCY, USE_TENANT_SPECIFIC_URL, ENABLE_SUBSCRIPTIONS } = process.env;
 
 const enableMultiTenancy = ENABLE_MULTI_TENANCY === 'true';
+const useTenantSpecificUrl = USE_TENANT_SPECIFIC_URL === 'true';
+const tenantIdClaimPath =
+    process.env.TENANT_ID_CLAIM_PATH !== '' ? process.env.TENANT_ID_CLAIM_PATH : 'custom:tenantId';
+const tenantIdClaimValuePrefix =
+    process.env.TENANT_ID_CLAIM_VALUE_PREFIX !== '' ? process.env.TENANT_ID_CLAIM_VALUE_PREFIX : undefined;
+const grantAccessAllTenantsScope =
+    process.env.GRANT_ACCESS_ALL_TENANTS_SCOPE !== '' ? process.env.GRANT_ACCESS_ALL_TENANTS_SCOPE : undefined;
+
 const enableSubscriptions = ENABLE_SUBSCRIPTIONS === 'true';
 
 export const fhirVersion: FhirVersion = '4.0.1';
@@ -138,8 +146,10 @@ export const getFhirConfig = async (): Promise<FhirConfig> => {
         multiTenancyConfig: enableMultiTenancy
             ? {
                   enableMultiTenancy: true,
-                  useTenantSpecificUrl: true,
-                  tenantIdClaimPath: 'custom:tenantId',
+                  useTenantSpecificUrl,
+                  tenantIdClaimPath,
+                  tenantIdClaimValuePrefix,
+                  grantAccessAllTenantsScope,
               }
             : undefined,
     };


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Serverless added if else switches to configure the API Gateway in order to support multi tenancy with specific url cleanly
Forward  "tenantIdClaimPath, tenantIdClaimValuePrefix, grantAccessAllTenantsScope" to the FhirConfig 
Added the following parameters to powershell and bash scripts
 --enableMultiTenancy
 --tenantIdClaimPath
 --tenantIdClaimValuePrefix
 --grantAccessAllTenantsScope

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
